### PR TITLE
Fix 'export' argument in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ results <- parSim(
     exclude = sample_size == 50 | beta <= 0.5,
 
     # The variables to export.
-    exports = c("bias"),
+    export = c("bias"),
 
     # No packages are required for export.
     packages = NULL,
@@ -145,7 +145,7 @@ results <- parSim(
     exclude = sample_size == 50,
 
     # The variables to export.
-    exports = c("bias"),
+    export = c("bias"),
 
     # No packages are required for export.
     packages = NULL,


### PR DESCRIPTION
C.f. change to argument name in 0b137db73e24542a03708877c894a858a7823023 ('exports' is now 'export')